### PR TITLE
feat: supports reporting Tower messages as BugSnag exceptions with proper severity set

### DIFF
--- a/lib/tower_bugsnag/reporter.ex
+++ b/lib/tower_bugsnag/reporter.ex
@@ -1,12 +1,4 @@
 defmodule TowerBugsnag.Reporter do
-  def report_event(%Tower.Event{kind: :message}) do
-    if enabled?() do
-      IO.puts("Bugsnag DOES NOT support reporting messages, ignoring...")
-    else
-      IO.puts("TowerBugsnag NOT enabled, ignoring...")
-    end
-  end
-
   def report_event(%Tower.Event{} = tower_event) do
     if enabled?() do
       tower_event


### PR DESCRIPTION
Messages can be reported anywhere with

````elixir
Tower.report_message(:error, "unexpected error")
````
```elixir
Tower.report_message(:warning, "be warn about this")
````
```elixir
Tower.report_message(:info, "something useful to know")
```

---

For what is worth, This provides something "similar" to what it was asked in https://github.com/bugsnag-elixir/bugsnag-elixir/issues/97.