### PR TITLE
fix: properly reports common abnormal `:gen_server` exits

### DIFF
--- a/lib/tower_bugsnag/bugsnag/event.ex
+++ b/lib/tower_bugsnag/bugsnag/event.ex
@@ -50,11 +50,13 @@ defmodule TowerBugsnag.Bugsnag.Event do
         plug_conn: plug_conn,
         metadata: metadata
       }) do
+    formatted_reason = Exception.format_exit(reason)
+
     %{
       exceptions: [
         %{
-          errorClass: "(exit) #{reason}",
-          message: reason,
+          errorClass: "(exit) #{formatted_reason}",
+          message: formatted_reason,
           stacktrace: stacktrace_entries(stacktrace)
         }
       ],


### PR DESCRIPTION
Extracted from #18.

---

https://github.com/mimiquate/elixir/blob/78f63d08313677a680868685701ae79a2459dcc1/lib/elixir/lib/exception.ex#L506-L522
https://github.com/erlang/otp/blob/f4d130fd3512875ee95ce05b30f77e7c7689915f/lib/stdlib/src/gen_fsm.erl#L1561-L1563